### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/IntegerHeap.py
+++ b/IntegerHeap.py
@@ -103,7 +103,7 @@ class FlatHeap:
     def _rangecheck(self,x):
         """Make sure x is a number we can include in this FlatHeap."""
         if x < 0 or x > self._max:
-            raise ValueError("FlatHeap: %s out of range" % repr(x))
+            raise ValueError("FlatHeap: {0!s} out of range".format(repr(x)))
 
     def __nonzero__(self):
         """True if this heap is nonempty, false if empty."""

--- a/Lyndon.py
+++ b/Lyndon.py
@@ -153,7 +153,7 @@ class LyndonTest(unittest.TestCase):
     
     def testNotLyndon(self):
         """Test that words that are not Lyndon words aren't claimed to be."""
-        nl = sum(1 for i in range(8**4) if isLyndonWord("%04o" % i))
+        nl = sum(1 for i in range(8**4) if isLyndonWord("{0:04o}".format(i)))
         self.assertEqual(nl,CountLyndonWords(8,4))
 
     def testDeBruijn(self):

--- a/Medium.py
+++ b/Medium.py
@@ -166,7 +166,7 @@ def StateTransitionGraph(M):
             St = M(S,t)
             if St != S:
                 if St in G[S]:
-                    raise MediumError("multiple adjacency from %s to %s" % (S,St))
+                    raise MediumError("multiple adjacency from {0!s} to {1!s}".format(S, St))
                 G[S][St] = t
     return G
 
@@ -188,7 +188,7 @@ class LabeledGraphMedium(Medium):
             for w in G[v]:
                 t = G[v][w]
                 if t in self._action[v]:
-                    raise MediumError("multiple edges for state %s and token %s" % (v,t))
+                    raise MediumError("multiple edges for state {0!s} and token {1!s}".format(v, t))
                 self._action[v][t] = w
                 if t not in self._reverse:
                     rt = G[w][v]
@@ -253,7 +253,7 @@ def RoutingTable(M):
         while True:
             i += 1
             if i >= len(activeTokens):
-                raise MediumError("no active token from %s to %s" %(S,current))
+                raise MediumError("no active token from {0!s} to {1!s}".format(S, current))
             if activeTokens[i] != inactivated and M(S,activeTokens[i]) != S:
                 activeForState[S] = i
                 statesForPos[i].append(S)

--- a/readUndirectedGraph.py
+++ b/readUndirectedGraph.py
@@ -35,7 +35,7 @@ def graphNum(s):
 	try:
 		return int(s)
 	except:
-		raise GraphFormatError, 'Number expected: "%s"' % s
+		raise GraphFormatError, 'Number expected: "{0!s}"'.format(s)
 
 def graph():
 	"""Create a new empty graph."""
@@ -50,11 +50,11 @@ def vertex(G, v):
 def edge(G,u,v,e):
 	"""Add edge e connecting vertices u and v in graph G.  Vertices must already be in G."""
 	if u == v:
-		raise GraphFormatError, 'Self-loop at %s' % str(u)
+		raise GraphFormatError, 'Self-loop at {0!s}'.format(str(u))
 	if u not in G:
-		raise GraphFormatError, 'Unexpected vertex %s in edge to %s' % (str(u),str(v))
+		raise GraphFormatError, 'Unexpected vertex {0!s} in edge to {1!s}'.format(str(u), str(v))
 	if v not in G:
-		raise GraphFormatError, 'Unexpected vertex %s in edge from %s' % (str(v),str(u))
+		raise GraphFormatError, 'Unexpected vertex {0!s} in edge from {1!s}'.format(str(v), str(u))
 	G[u][v] = G[v][u] = e
 
 
@@ -100,9 +100,9 @@ def readEdgeList(lines):
 	for line in filter(None,lines):
 		words = line.split()
 		if len(words) < 2 or len(words) > 3:
-			raise GraphFormatError, 'Wrong number of words in edge list: "%s"' % line
+			raise GraphFormatError, 'Wrong number of words in edge list: "{0!s}"'.format(line)
 		if len(words) == 3 and words[1] != '-':
-			raise GraphFormatError, 'Unrecognized edge type "%s" in edge list' % words[1]
+			raise GraphFormatError, 'Unrecognized edge type "{0!s}" in edge list'.format(words[1])
 		u, v = words[0], words[-1]
 		if u not in G:
 			vertex(G, u)
@@ -142,7 +142,7 @@ def readNodeEdgeList(lines):
 	def namedEdge(line):
 		id = line
 		if id in EdgeNames:
-			raise GraphFormatError, 'Edge name "%s" used twice in node edge list' % id
+			raise GraphFormatError, 'Edge name "{0!s}" used twice in node edge list'.format(id)
 		addEdge(next(lines), id)
 		EdgeNames[id] = id
 		
@@ -161,7 +161,7 @@ def readNodeEdgeList(lines):
 			try:
 				action = actions[line[3:]]
 			except KeyError:
-				raise GraphFormatError, 'Unrecognized section "%s" in node edge list' % line[3:]
+				raise GraphFormatError, 'Unrecognized section "{0!s}" in node edge list'.format(line[3:])
 		else:
 			action(line)
 
@@ -183,7 +183,7 @@ def readGraphML(lines):
 		context.append(name)
 		if len(context) == 1:
 			if name != 'graphml':
-				raise GraphFormatError, 'Unrecognized outer tag "%s" in GraphML' % name
+				raise GraphFormatError, 'Unrecognized outer tag "{0!s}" in GraphML'.format(name)
 		elif len(context) == 2 and name == 'graph':
 			if 'edgedefault' not in attrs:
 				raise GraphFormatError, 'Required attribute edgedefault missing in GraphML'
@@ -241,7 +241,7 @@ def readGraph6(str):
 	n, data = graph6n(data)
 	nd = (n*(n-1)//2 + 5) // 6
 	if len(data) != nd:
-		raise GraphFormatError, 'Expected %d bits but got %d in graph6' % (n*(n-1)//2, len(data)*6)
+		raise GraphFormatError, 'Expected {0:d} bits but got {1:d} in graph6'.format(n*(n-1)//2, len(data)*6)
 
 	def bits():
 		"""Return sequence of individual bits from 6-bit-per-value list of data values."""
@@ -339,12 +339,12 @@ def readLeda(lines):
 	for i in range(m):
 		words = next(lines).split()
 		if len(words) < 4:
-			raise GraphFormatError, 'Too few fields in LEDA.GRAPH edge %d' % (i+1)
+			raise GraphFormatError, 'Too few fields in LEDA.GRAPH edge {0:d}'.format((i+1))
 		source = graphNum(words[0])
 		target = graphNum(words[1])
 		reversal = graphNum(words[2])
 		if not reversal:
-			raise GraphFormatError, 'Edge %d is directed in LEDA.GRAPH' % (i+1)
+			raise GraphFormatError, 'Edge {0:d} is directed in LEDA.GRAPH'.format((i+1))
 		if source < target:
 			edge(G, source, target, i+1)
 	


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:vincentdavis:special-sequences?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:vincentdavis:special-sequences?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
